### PR TITLE
#14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "5.*",
+        "guzzlehttp/guzzle": "5.*"
+    },
+    "require-dev": {
         "phpunit/phpunit": "5.7"
     },
     "support": {


### PR DESCRIPTION
"phpunit/phpunit" should be in require-dev of composer.json

It is not good to have phpunit on prod. Usually we use composer install --no-dev