### PR TITLE
Bug fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "5.*",
+        "guzzlehttp/guzzle": "5.*"
+    },
+    "require-dev": {
         "phpunit/phpunit": "5.7"
     },
     "support": {

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -12274,7 +12274,7 @@ class TransactionBuilder
      */
     public function withItemDiscount($discounted)
     {
-        $l = GetMostRecentLine("WithItemDiscount");
+        $l = $this->GetMostRecentLine("WithItemDiscount");
         $l['discounted'] = $discounted;
         return $this;
     }
@@ -12326,7 +12326,7 @@ class TransactionBuilder
      */
     public function withLineParameter($name, $value)
     {
-        $l = GetMostRecentLine("WithLineParameter");
+        $l = $this->GetMostRecentLine("WithLineParameter");
         if (empty($l['parameters'])) $l['parameters'] = [];
         $l[$name] = $value;
         return $this;

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -12466,15 +12466,17 @@ class TransactionBuilder
      * @param   float               $amount      Value of the item.
      * @param   float               $quantity    Quantity of the item.
      * @param   string              $taxCode     Tax Code of the item. If left blank, the default item (P0000000) is assumed.
+     * @param   string              $itemCode    Item code/id in your application.
      * @return  TransactionBuilder
      */
-    public function withLine($amount, $quantity, $taxCode)
+    public function withLine($amount, $quantity, $taxCode, $itemCode = '')
     {
         $l = [
             'number' => $this->_line_number,
             'quantity' => $quantity,
             'amount' => $amount,
-            'taxCode' => $taxCode
+            'taxCode' => $taxCode,
+            'itemCode' => $itemCode
         ];
         array_push($this->_model['lines'], $l);
         $this->_line_number++;

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -12304,6 +12304,18 @@ class TransactionBuilder
     }
 
     /**
+     * Set the currencyCode
+     *
+     * @param   string              3 character ISO 4217 currency code.
+     * @return  TransactionBuilder
+     */
+    public function withCurrencyCode($currencyCode)
+    {
+        $this->_model['currencyCode'] = $currencyCode;
+        return $this;
+    }
+
+    /**
      * Add a parameter at the document level
      *
      * @param   string              name

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -12274,7 +12274,7 @@ class TransactionBuilder
      */
     public function withItemDiscount($discounted)
     {
-        $l = $this->GetMostRecentLine("WithItemDiscount");
+        $l = $this->getMostRecentLine("WithItemDiscount");
         $l['discounted'] = $discounted;
         return $this;
     }
@@ -12326,7 +12326,7 @@ class TransactionBuilder
      */
     public function withLineParameter($name, $value)
     {
-        $l = $this->GetMostRecentLine("WithLineParameter");
+        $l = $this->getMostRecentLine("WithLineParameter");
         if (empty($l['parameters'])) $l['parameters'] = [];
         $l[$name] = $value;
         return $this;
@@ -12393,7 +12393,7 @@ class TransactionBuilder
      */
     public function withLineAddress($type, $line1, $line2, $line3, $city, $region, $postalCode, $country)
     {
-        $line = $this->GetMostRecentLine("WithLineAddress");
+        $line = $this->getMostRecentLine("WithLineAddress");
         $line['addresses'][$type] = [
             'line1' => $line1,
             'line2' => $line2,
@@ -12448,7 +12448,7 @@ class TransactionBuilder
             throw new Exception("A valid date is required for a Tax Date Tax Override.");
         }
 
-        $line = $this->GetMostRecentLine("WithLineTaxOverride");
+        $line = $this->getMostRecentLine("WithLineTaxOverride");
         $line['taxOverride'] = [
             'type' => $type,
             'reason' => $reason,

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -12316,6 +12316,18 @@ class TransactionBuilder
     }
 
     /**
+     * Set the exemptionNo
+     *
+     * @param   string              Exemption Number for this document
+     * @return  TransactionBuilder
+     */
+    public function withExemptionNo($exemptionNo)
+    {
+        $this->_model['exemptionNo'] = $exemptionNo;
+        return $this;
+    }
+
+    /**
      * Add a parameter at the document level
      *
      * @param   string              name

--- a/src/AvaTaxClient.php
+++ b/src/AvaTaxClient.php
@@ -94,7 +94,14 @@ class AvaTaxClient
         return $this;
     }
 
-
+    /**
+     * 
+     * @return \GuzzleHttp\ClientInterface
+     */
+    public function getHttpClient()
+    {
+        return $this->client;
+    }
 
     /**
      * Retrieve all accounts


### PR DESCRIPTION
There is no way to set logger for GuzzleHttp\Client
Normaly I whould use $this->client->getEmitter()->attach($subscriber);

I suggest to add a new method AvaTaxClient::getHttpClient()