### PR TITLE
Allow passing $include params to txn builder

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -384,11 +384,12 @@ class TransactionBuilder
     /**
      * Create this transaction
      *
+     * @param string $include Specifies objects to include in the response after transaction is created
      * @return  TransactionModel
      */
-    public function create()
+    public function create($include = null)
     {
-        return $this->_client->createTransaction(null, $this->_model);
+        return $this->_client->createTransaction($include, $this->_model);
     }
 
     /**


### PR DESCRIPTION
Currently there is no way to pass include parameters when building a transaction using the TransactionBuilder class. For instance if you need access to `TransactionModel::$lines` you need to specify "?$include=Lines" on Api URL query string. There's currently no way to do that. This change allows you to pass in an include parameter when creating the Transaction so you can optionally specify if you want those fields populated.