### PR TITLE
method to support adding avalara lineitem models

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -189,7 +189,7 @@ class TransactionBuilder
      * @param   float               $longitude  The longitude of the geolocation for this transaction
      * @return  TransactionBuilder
      */
-     public function withLatLong($type, $latitude, $longitude)
+    public function withLatLong($type, $latitude, $longitude)
     {
         $this->_model['addresses'][$type] = [
             'latitude' => $latitude,
@@ -413,8 +413,8 @@ class TransactionBuilder
      *
      * @return  TransactionBuilder
      */
-    public function withLineItem($thing) {
-
+    public function withLineItem($thing)
+    {
         $mode = is_array($thing) ? 'multi' : 'single';
 
         if ($mode === 'single') {

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -407,5 +407,30 @@ class TransactionBuilder
             'adjustmentReason' => $reason
         ];
     }
+    
+    /**
+     * Add Avalara LineItemModel objects to the lines array
+     *
+     * @return  TransactionBuilder
+     */
+    public function withLineItem($thing) {
+
+        $mode = is_array($thing) ? 'multi' : 'single';
+
+        if ($mode === 'single') {
+            $this->_model['lines'][] = (array)$thing;
+            $this->_line_number++;
+        }
+
+
+        if ($mode === 'multi') {
+            foreach($thing as $lineItem) {
+                $this->_model['lines'][] = (array)$lineItem;
+                $this->_line_number++;
+            }
+        }
+
+        return $this;
+    }    
 }
 ?>


### PR DESCRIPTION
This code adds a `withLineItem` method to the TransactionBuilder so that a user can instantiate one or more Avalara LineItemModel objects, setting all the properties they need for each line item and then using this method to add those to the TransactionBuilders lines array to be sent during a `createTransaction()` call.

Please see [this gist](https://gist.github.com/caleywoods/ca9e972642f3dc0820de246beda9beee) that illustrates how I am using this to create transactions in Avalara right now. 