### PR TITLE
Fixed bug in TransactionBuilder getCurrentLineNumber

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -538,7 +538,8 @@ class TransactionBuilder
     public function getCurrentLineNumber()
     {
         try {
-            return $this->getMostRecentLineIndex();
+            $li = $this->getMostRecentLineIndex();
+            return $this->_model['lines'][$li]['number'];
         } catch (\Exception $e) {
             return null;
         }


### PR DESCRIPTION
getCurrentLineNumber method added to TransactionBuilder previously returned the array index of the line instead of the actual line number (offset from each other by 1).