### PR TITLE
Add support for setting IsSellerImporterOfRecord with Transaction Builder

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -185,11 +185,13 @@ class TransactionBuilder
     /**
      * Set flag for seller as importer of record
      *
+     * @param bool $isSeller
+     *
      * @return TransactionBuilder
      */
-    public function withSellerIsImporterOfRecord()
+    public function withSellerIsImporterOfRecord($isSeller = true)
     {
-        $this->_model['isSellerImporterOfRecord'] = true;
+        $this->_model['isSellerImporterOfRecord'] = $isSeller;
         return $this;
     }
 


### PR DESCRIPTION
With the current version of the transaction builder, you cannot set `IsSellerImporterOfRecord` to false, this PR rectifies that.