### PR TITLE
Fix incorrectly namespaced init exception

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -51,12 +51,14 @@ class AvaTaxClientBase
      * @param string $machineName  Specify the machine name of the machine on which this code is executing here.  Should not contain any semicolons.
      * @param string $environment  Indicates which server to use; acceptable values are "sandbox" or "production", or the full URL of your AvaTax instance.
      * @param array $guzzleParams  Extra parameters to pass to the guzzle HTTP client (http://docs.guzzlephp.org/en/latest/request-options.html)
+     *
+     * @throws \Exception
      */
     public function __construct($appName, $appVersion, $machineName="", $environment, $guzzleParams = [])
     {
         // app name and app version are mandatory fields.
         if ($appName == "" || $appName == null || $appVersion == "" || $appVersion == null) {
-            throw new Exception('appName and appVersion are manadatory fields!');
+            throw new \Exception('appName and appVersion are mandatory fields!');
         }
 
         // machine name is nullable, but must be empty string to avoid error when concat in client string.
@@ -153,25 +155,28 @@ class AvaTaxClientBase
      * @param string $apiUrl           The relative path of the API on the server
      * @param string $verb             The HTTP verb being used in this request
      * @param string $guzzleParams     The Guzzle parameters for this request, including query string and body parameters
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Exception
      */
     protected function restCall($apiUrl, $verb, $guzzleParams)
     {
         // Set authentication on the parameters
-        if(count($this->auth) == 2){
-		if (!isset($guzzleParams['auth'])){
-			$guzzleParams['auth'] = $this->auth;
-		}
-		$guzzleParams['headers'] = [
-			'Accept' => 'application/json',
-			'X-Avalara-Client' => "{$this->appName}; {$this->appVersion}; PhpRestClient; 18.10.5-260; {$this->machineName}"
-		];
-	 } else {
-		$guzzleParams['headers'] = [
-			'Accept' => 'application/json',
-			'Authorization' => 'Bearer '.$this->auth[0],
-			'X-Avalara-Client' => "{$this->appName}; {$this->appVersion}; PhpRestClient; 18.10.5-260; {$this->machineName}"
-		];
-	 }
+        if (count($this->auth) == 2) {
+            if (!isset($guzzleParams['auth'])) {
+                $guzzleParams['auth'] = $this->auth;
+            }
+            $guzzleParams['headers'] = [
+                'Accept' => 'application/json',
+                'X-Avalara-Client' => "{$this->appName}; {$this->appVersion}; PhpRestClient; 18.10.5-260; {$this->machineName}"
+            ];
+        } else {
+            $guzzleParams['headers'] = [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer '.$this->auth[0],
+                'X-Avalara-Client' => "{$this->appName}; {$this->appVersion}; PhpRestClient; 18.10.5-260; {$this->machineName}"
+            ];
+        }
 
         // Contact the server
         try {
@@ -186,4 +191,3 @@ class AvaTaxClientBase
         }
     }
 }
-?>

--- a/tests/basicWorkflowTest.php
+++ b/tests/basicWorkflowTest.php
@@ -7,6 +7,14 @@ use PHPUnit\Framework\TestCase;
  */
 final class AvaTaxClientTest extends TestCase
 {
+    /**
+     * @expectedException \Exception
+     */
+    public function testConstructorThrowsExceptionForMissingRequirements()
+    {
+        new Avalara\AvaTaxClient('', '', '', '');
+    }
+    
     public function testBasicWorkflow()
     {
         // Create a new client
@@ -82,11 +90,5 @@ final class AvaTaxClientTest extends TestCase
         // Call 'Ping' to verify that we are connected
         $p = $client->Ping();
         $this->assertNotNull($p, "Should be able to call Ping");
-
     }
-
 }
-
-
-
-?>


### PR DESCRIPTION
## Problem
The constructor parameter check fails when it throws an `Exception` without a namespace. This results in an error of `Class 'Avalara\Exception' not found` instead of throwing a proper exception. 

## Solution
This PR changes the `Exception` to `\Exception` to make sure that the constructor can locate the exception class.

In addition, this PR:

1. Fixes a minor misspelling in `mandatory`
1. Adds a new test for the exception behavior
1. Normalized some tab characters
1. Removes trailing `?>` php terminators, the [preferred option](http://php.net/basic-syntax.phptags) for pure php files.

## Code Review Notes
This should have no impact on the application, it's just patching up a broken exception during init.
