### PR TITLE
Updated Tests and Updated GuzzleHttp Version to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ echo('<pre>' . json_encode($t, JSON_PRETTY_PRINT) . '</pre>');
 
 ?>
 ```
+
+# Running the Tests
+
+Update the `tests/phpunit.xml` set the <env> `SANDBOX_USERNAME` and the `SANDBOX_PASSWORD` to your username and password.
+
+You can then run the tests using phpunit with the following command: `phpunit -c tests/phpunit.xml`

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6"
+        "guzzlehttp/guzzle": "~7"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7"

--- a/tests/basicWorkflowTest.php
+++ b/tests/basicWorkflowTest.php
@@ -12,6 +12,8 @@ final class AvaTaxClientTest extends TestCase
      */
     public function testConstructorThrowsExceptionForMissingRequirements()
     {
+        $this->expectException('Exception');
+
         new Avalara\AvaTaxClient('', '', '', '');
     }
     

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,4 +2,8 @@
     <testsuite name="AvaTaxClient">
         <directory>./</directory>
     </testsuite>
+    <php>
+        <env name="SANDBOX_USERNAME" value="CHANGE_ME" force="true" />
+        <env name="SANDBOX_PASSWORD" value="CHANGE_ME" force="true" />
+    </php>
 </phpunit>


### PR DESCRIPTION
GuzzleHttp is required in quite a few widely used packages in the PHP ecosystem, in particular [Laravel 8.0](https://github.com/laravel/framework).  While trying to update my application to laravel 8.0 I noticed their were dependency issues with AvaTax-REST-V2-PHP-SDK.  I updated the GuzzleHttp version to 7.0, and I also went ahead and fixed the tests so that they would pass correctly.  There is also the addition of environment variables in the phpunit.xml so that testers can test against their own sandbox accounts. 