### PR TITLE
support more php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 php:
   - '5.6'
+  - '7.2'
+  - '7.3'
+  - '7.4'
+  - '8.0'
 
 before_script: composer install
 

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6"
+        "guzzlehttp/guzzle": "~6|~7"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7"
+        "phpunit/phpunit": ">=5.7"
     },
     "support": {
         "docs": "https://developer.avalara.com",

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,7 @@ class AvaTaxClientBase
      *
      * @throws \Exception
      */
-    public function __construct($appName, $appVersion, $machineName="", $environment, $guzzleParams = [])
+    public function __construct($appName, $appVersion, $machineName="", $environment=null, $guzzleParams = [])
     {
         // app name and app version are mandatory fields.
         if ($appName == "" || $appName == null || $appVersion == "" || $appVersion == null) {

--- a/src/ClientExtensionExample.php
+++ b/src/ClientExtensionExample.php
@@ -18,7 +18,7 @@ class ClientExtensionExample extends AvaTaxClient
      * @param string $environment  Indicates which server to use; acceptable values are "sandbox" or "production", or the full URL of your AvaTax instance.
      * @param array $guzzleParams  Extra parameters to pass to the guzzle HTTP client (http://docs.guzzlephp.org/en/latest/request-options.html)
      */
-    public function __construct($appName, $appVersion, $machineName="", $environment, $guzzleParams = [], $clientConfig = null)
+    public function __construct($appName, $appVersion, $machineName="", $environment=null, $guzzleParams = [], $clientConfig = null)
     {
         parent::__construct($appName, $appVersion, $machineName, $environment, $guzzleParams);
         $this->clientConfig = $clientConfig;

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -4192,7 +4192,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $countryCode If not null, return all records with this code.
      * @return FetchResult
      */
-    public function listProductClassificationSystems($filter=null, $top=null, $skip=null, $orderBy=null, $countryCode)    {
+    public function listProductClassificationSystems($filter=null, $top=null, $skip=null, $orderBy=null, $countryCode=null)    {
         $path = "/api/v2/definitions/productclassificationsystems";
         $guzzleParams = [
             'query' => ['$filter' => $filter, '$top' => $top, '$skip' => $skip, '$orderBy' => $orderBy, '$countryCode' => $countryCode],
@@ -4218,7 +4218,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $countryCode If not null, return all records with this code.
      * @return FetchResult
      */
-    public function listProductClassificationSystemsByCompany($companyCode, $filter=null, $top=null, $skip=null, $orderBy=null, $countryCode)    {
+    public function listProductClassificationSystemsByCompany($companyCode, $filter=null, $top=null, $skip=null, $orderBy=null, $countryCode=null)    {
         $path = "/api/v2/definitions/productclassificationsystems/bycompany/{$companyCode}";
         $guzzleParams = [
             'query' => ['$filter' => $filter, '$top' => $top, '$skip' => $skip, '$orderBy' => $orderBy, '$countryCode' => $countryCode],
@@ -6383,7 +6383,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param AdjustMultiDocumentModel $model The adjust request you wish to execute
      * @return MultiDocumentModel
      */
-    public function adjustMultiDocumentTransaction($code, $type, $include=null, $model)    {
+    public function adjustMultiDocumentTransaction($code, $type, $include=null, $model=null)    {
         $path = "/api/v2/transactions/multidocument/{$code}/type/{$type}/adjust";
         $guzzleParams = [
             'query' => ['include' => $include],
@@ -6529,7 +6529,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param CreateMultiDocumentModel $model the multi document transaction model
      * @return MultiDocumentModel
      */
-    public function createMultiDocumentTransaction($include=null, $model)    {
+    public function createMultiDocumentTransaction($include=null, $model=null)    {
         $path = "/api/v2/transactions/multidocument";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -6747,7 +6747,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param RefundTransactionModel $model Information about the refund to create
      * @return MultiDocumentModel
      */
-    public function refundMultiDocumentTransaction($code, $type, $include=null, $model)    {
+    public function refundMultiDocumentTransaction($code, $type, $include=null, $model=null)    {
         $path = "/api/v2/transactions/multidocument/{$code}/type/{$type}/refund";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -8870,7 +8870,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param AddTransactionLineModel $model information about the transaction and lines to be added
      * @return TransactionModel
      */
-    public function addLines($include=null, $model)    {
+    public function addLines($include=null, $model=null)    {
         $path = "/api/v2/companies/transactions/lines/add";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -8925,7 +8925,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param AdjustTransactionModel $model The adjustment you wish to make
      * @return TransactionModel
      */
-    public function adjustTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function adjustTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/adjust";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9102,7 +9102,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param ChangeTransactionCodeModel $model The code change request you wish to execute
      * @return TransactionModel
      */
-    public function changeTransactionCode($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function changeTransactionCode($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/changecode";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9155,7 +9155,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param CommitTransactionModel $model The commit request you wish to execute
      * @return TransactionModel
      */
-    public function commitTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function commitTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/commit";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9211,7 +9211,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param CreateOrAdjustTransactionModel $model The transaction you wish to create or adjust
      * @return TransactionModel
      */
-    public function createOrAdjustTransaction($include=null, $model)    {
+    public function createOrAdjustTransaction($include=null, $model=null)    {
         $path = "/api/v2/transactions/createoradjust";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -9274,7 +9274,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param CreateTransactionModel $model The transaction you wish to create
      * @return TransactionModel
      */
-    public function createTransaction($include=null, $model)    {
+    public function createTransaction($include=null, $model=null)    {
         $path = "/api/v2/transactions/create";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -9314,7 +9314,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param RemoveTransactionLineModel $model information about the transaction and lines to be removed
      * @return TransactionModel
      */
-    public function deleteLines($include=null, $model)    {
+    public function deleteLines($include=null, $model=null)    {
         $path = "/api/v2/companies/transactions/lines/delete";
         $guzzleParams = [
             'query' => ['$include' => $include],
@@ -9551,7 +9551,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param LockTransactionModel $model The lock request you wish to execute
      * @return TransactionModel
      */
-    public function lockTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function lockTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/lock";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9617,7 +9617,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param RefundTransactionModel $model Information about the refund to create
      * @return TransactionModel
      */
-    public function refundTransaction($companyCode, $transactionCode, $include=null, $documentType, $useTaxDateOverride, $model)    {
+    public function refundTransaction($companyCode, $transactionCode, $include=null, $documentType=null, $useTaxDateOverride=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/refund";
         $guzzleParams = [
             'query' => ['$include' => $include, 'documentType' => $documentType, 'useTaxDateOverride' => $useTaxDateOverride],
@@ -9670,7 +9670,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param SettleTransactionModel $model The data from an external system to reconcile against AvaTax
      * @return TransactionModel
      */
-    public function settleTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function settleTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/settle";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9813,7 +9813,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param VerifyTransactionModel $model The data from an external system to reconcile against AvaTax
      * @return TransactionModel
      */
-    public function verifyTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function verifyTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/verify";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],
@@ -9867,7 +9867,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param VoidTransactionModel $model The void request you wish to execute. To void a transaction the code must be set to 'DocVoided'
      * @return TransactionModel
      */
-    public function voidTransaction($companyCode, $transactionCode, $documentType, $include=null, $model)    {
+    public function voidTransaction($companyCode, $transactionCode, $documentType, $include=null, $model=null)    {
         $path = "/api/v2/companies/{$companyCode}/transactions/{$transactionCode}/void";
         $guzzleParams = [
             'query' => ['documentType' => $documentType, '$include' => $include],

--- a/tests/basicWorkflowTest.php
+++ b/tests/basicWorkflowTest.php
@@ -8,10 +8,11 @@ use PHPUnit\Framework\TestCase;
 final class AvaTaxClientTest extends TestCase
 {
     /**
-     * @expectedException \Exception
      */
     public function testConstructorThrowsExceptionForMissingRequirements()
     {
+        $this->expectException(Exception::class);
+
         new Avalara\AvaTaxClient('', '', '', '');
     }
     


### PR DESCRIPTION
adds travis testing for php versions 7.2, 7.3, 7.4 and 8.0
 (php 7.0 and 7.1 don't get the correct version of phpunit and thus fails)
update invalid function definitions which has required params after
 optional ones (php8.0 refuses to build with these errors)
add guzzle 7 support
closes #119
closes #129