### PR TITLE
support guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6"
+        "guzzlehttp/guzzle": "~6|~7"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7"


### PR DESCRIPTION
This adds support for guzzle 7 while still maintaining compatibility with guzzle 6.

There are a bunch of other PRs here for support for guzzle 7 but they all either remove the guzzle 6 support or add other things in addition to guzzle 7 support.

I figured this PR might have a higher chance of getting merged to give us the guzzle 7 support with the least friction of getting merged by having to review other changes. As well as not preventing anyone still using guzzle 6 from updating.

Fix #119