### PR TITLE
Fixes for 22.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "guzzlehttp/guzzle": "~6|~7"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7"
+        "phpunit/phpunit": ">=5.7"
     },
     "support": {
         "docs": "https://developer.avalara.com",

--- a/src/Client.php
+++ b/src/Client.php
@@ -159,7 +159,7 @@ class AvaTaxClientBase
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Exception
      */
-    protected function restCall($apiUrl, $verb, $guzzleParams, $apiversion='')
+    protected function restCall($apiUrl, $verb, $guzzleParams, $apiversion='',$headerParams=null)
     {
         // Set authentication on the parameters
         if (count($this->auth) == 2) {
@@ -177,7 +177,10 @@ class AvaTaxClientBase
                 'X-Avalara-Client' => "{$this->appName}; {$this->appVersion}; PhpRestClient; {$apiversion}; {$this->machineName}"
             ];
         }
-        
+        if (isset($headerParams) )
+        {
+            $guzzleParams['headers']= $guzzleParams['headers']+$headerParams;
+        }
         // Check the client config, if set - update guzzleParams['timeout'] 
         if (isset($this->client->getConfig()['timeout']) ) {
             $guzzleParams['timeout'] = $this->client->getConfig()['timeout'];

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,7 @@ class AvaTaxClientBase
      *
      * @throws \Exception
      */
-    public function __construct($appName, $appVersion, $machineName="", $environment, $guzzleParams = [])
+    public function __construct($appName, $appVersion, $machineName="", $environment="", $guzzleParams = [])
     {
         // app name and app version are mandatory fields.
         if ($appName == "" || $appName == null || $appVersion == "" || $appVersion == null) {

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -211,6 +211,19 @@ class TransactionBuilder
         return $this;
     }
 
+     /**
+     * Specific a exchange rate currency code for this transaction
+     *
+     * @param   string              $exchangeRateCurrencyCode Specific the three-character ISO 4217 code that is being used for exchange rate for this transaction (optional)
+     * @return  TransactionBuilder
+     */
+    public function withExchangeRateCurrencyCode($exchangeRateCurrencyCode)
+    {
+        $this->_model['exchangeRateCurrencyCode'] = $exchangeRateCurrencyCode;
+
+        return $this;
+    }
+       
     /**
      * Add a parameter at the document level
      *


### PR DESCRIPTION
Fixes for : 
 S-21 : SDK TransactionBuilder does not support the exchangeRateCurrencyCode field
AS-24 : Support new parameters in ASV Swagger 
APIPLAT-5412: PHP 8 support - remove warnings

