### PR TITLE
AS-114: Handling response when content type is text/csv. Earlier it was resulting in unexpected error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -214,7 +214,11 @@ class AvaTaxClientBase
             $code=$response->getStatusCode();
             $contentTypes =  $response->getHeader('Content-Type');
             
-            if ( in_array ("application/json",$contentTypes))
+            if ( in_array ("text/csv", $contentTypes)) {
+                return $body;
+            }
+
+            if ( in_array ("application/json", $contentTypes))
             {
                 if ($contentLength!=null and $length ==0 and intdiv($code , 100) ==2 ){
                         return null;                

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -9305,10 +9305,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $region A two character region code which limits results to a specific region.
      * @return object
      */
-    public function downloadTaxRatesByZipCode($date = null, $region = null)    {
-        if(is_null($date)) {
-            $date = date("Y-m-d"); 
-        }
+    public function downloadTaxRatesByZipCode($date, $region = null)    {
         $path = "/api/v2/taxratesbyzipcode/download/{$date}";
         $guzzleParams = [
             'query' => ['region' => $region],
@@ -10064,6 +10061,7 @@ class AvaTaxClient extends AvaTaxClientBase
      */
     public function createTransaction($include=null, $model=null)    {
         $path = "/api/v2/transactions/create";
+        echo json_encode($model);
         $guzzleParams = [
             'query' => ['$include' => $include],
             'body' => json_encode($model)

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -9305,7 +9305,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $region A two character region code which limits results to a specific region.
      * @return object
      */
-    public function downloadTaxRatesByZipCode($date, $region)    {
+    public function downloadTaxRatesByZipCode($date, $region = null)    {
         $path = "/api/v2/taxratesbyzipcode/download/{$date}";
         $guzzleParams = [
             'query' => ['region' => $region],

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -9305,7 +9305,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $region A two character region code which limits results to a specific region.
      * @return object
      */
-    public function downloadTaxRatesByZipCode($date, $region = null)    {
+    public function downloadTaxRatesByZipCode($date, $region)    {
         $path = "/api/v2/taxratesbyzipcode/download/{$date}";
         $guzzleParams = [
             'query' => ['region' => $region],
@@ -10061,7 +10061,6 @@ class AvaTaxClient extends AvaTaxClientBase
      */
     public function createTransaction($include=null, $model=null)    {
         $path = "/api/v2/transactions/create";
-        echo json_encode($model);
         $guzzleParams = [
             'query' => ['$include' => $include],
             'body' => json_encode($model)

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -9305,7 +9305,10 @@ class AvaTaxClient extends AvaTaxClientBase
      * @param string $region A two character region code which limits results to a specific region.
      * @return object
      */
-    public function downloadTaxRatesByZipCode($date, $region = null)    {
+    public function downloadTaxRatesByZipCode($date = null, $region = null)    {
+        if(is_null($date)) {
+            $date = date("Y-m-d"); 
+        }
         $path = "/api/v2/taxratesbyzipcode/download/{$date}";
         $guzzleParams = [
             'query' => ['region' => $region],


### PR DESCRIPTION
This fix will resolve the following:
When content type is text/csv, then response parsing to json should not happen. Rather response body should be returned. This way based on Content Type and Body, the users at client would be able to download the file.