### PR TITLE
AS-115:How to specify a unit for parameters that accept units

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -255,6 +255,29 @@ class TransactionBuilder
         return $this;
     }
 
+        /**
+     * Add a parameter to the current line when unit is specified
+     *
+     * @param   string              name
+     * @param   string              value
+     * @param   string              unit
+     * @return  TransactionBuilder
+     */
+    public function withLineParameterAndUnit($name, $value, $unit)
+    {
+        $li = $this->getMostRecentLineIndex();
+        if (empty($this->_model['lines'][$li]['parameters'])) {
+            $this->_model['lines'][$li]['parameters'] = [];
+        }
+        $l = [
+            'name' => $name,
+            'value' => $value,
+            'unit' => $unit
+        ];
+        $this->_model['lines'][$li]['parameters'][] = $l;
+        return $this;
+    }
+
     /**
      * Add an address to this transaction
      *


### PR DESCRIPTION
As mentioned in the original github issue, this feature is already available in C# and Java SDK.

In the current implementation of PHP SDK, we don't have a way to specify the units for line parameters and by default it always ends up with "Meter".
The _parameters_ in response currently looks like:
`"parameters": [
                {
                    "name": "ScreenSize",
                    "value": "22",
                    "unit": "Meter"
                }
            ],`
          
 With new changes, we added a new function which takes units as a parameter and the same ends up being used and the request would like the following:
 
`$tb = new Avalara\TransactionBuilder($client, "DEFAULT", Avalara\DocumentType::C_SALESINVOICE, 'ABC'); `
  `$t = $tb->withAddress('SingleLocation', '123 Main Street', null, null, 'Irvine', 'CA', '92615', 'US')
    ->withLine(100.0, 1, null, "P0000000")
    ->withLineParameterAndUnit("ScreenSize", 22.0, "inch")
    ->create();`
    
And the response would look like: (Function override is not an option in PHP)

`            "parameters": [
                {
                    "name": "ScreenSize",
                    "value": "22",
                    "unit": "Inch"
                }
            ],`