### PR TITLE
Add SalesPerson Code

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -147,6 +147,18 @@ class TransactionBuilder
     }
 
     /**
+     * Set client application customer or usage type
+     *
+     * @param   string              code    (See API endpoint `/api/v2/definitions/entityusecodes` for a list of allowable values)
+     * @return TransactionBuilder
+     */
+    public function withSalesPersonCode($code)
+    {
+        $this->_model['salespersonCode'] = $code;
+        return $this;
+    }
+
+    /**
      * Set purchase order number
      *
      * @param   string              no


### PR DESCRIPTION
Allowed to add salesPersonCode to the Transaction Builder.

Since the model is private, and have no way of assign it, we had to duplicate this file, in order to have that small change.
So please, accept this change in order to keep on using the right class