### PR TITLE
adding-tls-1.2: Change the protocol version to 1.2

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -200,8 +200,8 @@ class AvaTaxClientBase
         }
         
         //Set TLS version to 1.2 because Avartax is discontinuing support TLS 1.0 & 1.1
-        if(empty($guzzleParams['version'])){
-            $guzzleParams['version'] = '1.2';
+        if (version_compare(PHP_VERSION, '5.6.3', '>=')) {
+            $guzzleParams['curl'][CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1_2;
         }
         
         // Contact the server

--- a/src/Client.php
+++ b/src/Client.php
@@ -199,6 +199,11 @@ class AvaTaxClientBase
             $guzzleParams['connect_timeout'] = 1200;
         }
         
+        //Set TLS version to 1.2 because Avartax is discontinuing support TLS 1.0 & 1.1
+        if(empty($guzzleParams['version'])){
+            $guzzleParams['version'] = '1.2';
+        }
+        
         // Contact the server
         try {
             $response = $this->client->request($verb, $apiUrl, $guzzleParams);


### PR DESCRIPTION
## Description
- Adding default protocol version to src/Client.php
- Setting up the default protocol to 1.2, since Avatax is is discontinuing support TLS 1.0 & 1.1

## How To Reproduce
Steps to reproduce the behavior:
- Goes to admin and config avatax account
- Check the connection status

## Expected behavior
- The API connection protocol for Avatax will be updated to version 1.2.

## Benefits
- Since Guzzle's Client uses 1.1 as the default protocol, the default protocol is being updated from 1.1 to 1.2.

## Additional information
- N/A