### PR TITLE
AS-145: Add logging to V2 PHP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,40 @@ echo('<pre>' . json_encode($t, JSON_PRETTY_PRINT) . '</pre>');
 
 ?>
 ```
+# How to enable logging in the PHP SDK
+Logging could be enabled on client side by adding logging library like Monolog. This could be done by adding dependency and version in composer.json
+```
+"require": {
+        ....
+        ....
+        "monolog/monolog": "^3.2"
+    },
+``` 
+By just adding the above configuration, the logging framework will recognise the binding. Now, we will have to provide logging object as contructor parameter to AvaTaxClient. This could be done as below:
+```
+// Include the packages/classes we would need to create the logger object
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Processor\PsrLogMessageProcessor;
+```
+
+The following example shows how we can add configuration to display logs at console (stdout)
+```
+$stream_handler = new StreamHandler("php://stdout");
+
+$stream_handler->setFormatter(new JsonFormatter());
+
+// Follow PSR-3 specificaiton.
+$psrProcessor = new PsrLogMessageProcessor();
+
+$logger = new Logger('appLogger', [$stream_handler], [
+    $psrProcessor,
+  ]);
+
+// Create a new client
+$client = new Avalara\AvaTaxClient('phpTestApp', '1.0', 'localhost', 'sandbox',[], $logger, true);
+```
+
+This should add logging to SDK and the logs would be displayed on console. If we want to use other configurations where we want logs to be stored in files etc then the handler(StreamHandler in above case) would require changes accordingly.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ echo('<pre>' . json_encode($t, JSON_PRETTY_PRINT) . '</pre>');
 ?>
 ```
 # How to enable logging in the PHP SDK
+* SDK uses PSR-3, a common interface used for logging capabilities in PHP.
+* Client would implement the binding on their end like Monolog, Analog etc to enable logging.
+* By default there is no logging enabled.
+* All the attributes which are part of log message are in **LogObject.php**
+* To enable or disable logging of request and response object, there is a boolean variable **includeReqResInLogging** passed as constructor argument. Default is set to **FALSE**
+* Output of logging is in **JSON** format.
+
+
 Logging could be enabled on client side by adding logging library like Monolog. This could be done by adding dependency and version in composer.json
 ```
 "require": {

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ echo('<pre>' . json_encode($t, JSON_PRETTY_PRINT) . '</pre>');
 * Client would implement the binding on their end like Monolog, Analog etc to enable logging.
 * By default there is no logging enabled.
 * All the attributes which are part of log message are in **LogObject.php**
-* To enable or disable logging of request and response object, there is a boolean variable **includeReqResInLogging** passed as constructor argument. Default is set to **FALSE**
+* To enable or disable logging of request and response object, there is a boolean variable **logRequestAndResponseBody** passed as constructor argument. Default is set to **FALSE**
 * Output of logging is in **JSON** format.
 
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6|~7"
+        "guzzlehttp/guzzle": "~6|~7",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7"

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Avalara;
 use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
 
 /**
  * Base AvaTaxClient object that handles connectivity to the AvaTax v2 API server.
@@ -44,6 +45,16 @@ class AvaTaxClientBase
     protected $catchExceptions;
 
     /**
+     * @var LoggerInterface The logger instance which is intended to be used for logging puposes      
+     */
+    protected $logger;
+
+    /**
+     * @var bool        The setting for whether the request and response body should be logged or not
+     */
+    protected $includeReqResInLogging;
+
+    /**
      * Construct a new AvaTaxClient
      *
      * @param string $appName      Specify the name of your application here.  Should not contain any semicolons.
@@ -54,7 +65,7 @@ class AvaTaxClientBase
      *
      * @throws \Exception
      */
-    public function __construct($appName, $appVersion, $machineName="", $environment="", $guzzleParams = [])
+    public function __construct($appName, $appVersion, $machineName="", $environment="", $guzzleParams = [], LoggerInterface $logger = null, $includeReqResInLogging = false)
     {
         // app name and app version are mandatory fields.
         if ($appName == "" || $appName == null || $appVersion == "" || $appVersion == null) {
@@ -86,6 +97,8 @@ class AvaTaxClientBase
 
         // Configure the HTTP client
         $this->client = new Client($guzzleParams);
+        $this->logger = $logger;
+        $this->includeReqResInLogging = $includeReqResInLogging;
     }
 
     /**
@@ -161,6 +174,10 @@ class AvaTaxClientBase
      */
     protected function restCall($apiUrl, $verb, $guzzleParams, $apiversion='',$headerParams=null)
     {
+        // Populate the log object with request details
+        $logModel = new LogInformation();
+        $logModel-> populateRequestInfo($verb, $apiUrl, $guzzleParams, $this->includeReqResInLogging);
+        
         // Set authentication on the parameters
         if (count($this->auth) == 2) {
             if (!isset($guzzleParams['auth'])) {
@@ -201,6 +218,7 @@ class AvaTaxClientBase
         
         // Contact the server
         try {
+            $logModel-> setStartTime(microtime(true));
             $response = $this->client->request($verb, $apiUrl, $guzzleParams);
             $body = $response->getBody();
 
@@ -227,18 +245,33 @@ class AvaTaxClientBase
             $JsonBody = json_decode($body);
             if (is_null($JsonBody)) {
                 if (json_last_error() === JSON_ERROR_SYNTAX) {
-				     throw new \Exception('The response is in unexpected format. The response is: ' . $JsonBody);
-			     }
-              return $body;
+                    $errorMsg = 'The response is in unexpected format. The response is: ';
+                    // populate exception details in log object
+                    $logModel-> populateErrorInfoWithMessageAndBody($errorMsg, $response);
+				    throw new \Exception($errorMsg . $JsonBody);
+			    }
+                $logModel-> populateResponseInfo($body, $response);
+                return $body;
             } else {
-              return $JsonBody;
+                $logModel-> populateResponseInfo($JsonBody, $response);
+                return $JsonBody;
             }
 
         } catch (\GuzzleHttp\Exception\ClientException $e) {
+            // populate exception details in log object
+            $logModel-> populateErrorInfo($e);
             if (!$this->catchExceptions) {
                 throw $e;
             }
             return $e->getResponse()->getBody()->getContents();
+        } finally {
+            // log the error / info details
+            if(!is_null($logModel-> statusCode) && $logModel-> statusCode < 400) {
+                $this-> logger-> info(json_encode($logModel));
+            } else {
+                $this-> logger-> error(json_encode($logModel));
+            }
+
         }
     }
 }

--- a/src/LogObject.php
+++ b/src/LogObject.php
@@ -45,6 +45,7 @@ class LogInformation
     {
         $this-> populateCommonResponseInfo($response);
         $this-> exceptionMessage = $errorMessage;
+        $this-> statusCode = 500;
     }
 
     public function populateErrorInfo($e)

--- a/src/LogObject.php
+++ b/src/LogObject.php
@@ -1,0 +1,72 @@
+<?php
+namespace Avalara;
+
+class LogInformation
+{
+    private $startTime;
+    private $includeReqResInLogging;
+    public $httpMethod;
+    public $headerCorrelationId;
+    public $requestDetails;
+    public $responseDetails;
+    public $requestURI;
+    public $totalExecutionTime;
+    public $statusCode;
+    public $timestamp;
+    public $exceptionMessage;
+
+    public function setStartTime($startTime)
+    {
+        $this-> startTime = $startTime;
+    }
+
+    public function populateRequestInfo($verb, $apiUrl, $guzzleParams, $includeReqResInLogging)
+    {
+        $this-> timestamp = gmdate("Y/m/d H:i:s");
+        $this-> httpMethod = $verb;
+        $this-> requestURI = $apiUrl;
+        $this-> includeReqResInLogging = $includeReqResInLogging;
+        if($this-> includeReqResInLogging)
+        {
+            $this-> requestDetails = $guzzleParams['body'];
+        }
+    }
+
+    public function populateResponseInfo($jsonBody, $response)
+    {
+        $this-> populateCommonResponseInfo($response);
+        if($this-> includeReqResInLogging)
+        {
+            $this-> responseDetails = $jsonBody;
+        }
+    }
+
+    public function populateErrorInfoWithMessageAndBody($errorMessage, $response) 
+    {
+        $this-> populateCommonResponseInfo($response);
+        $this-> exceptionMessage = $errorMessage;
+    }
+
+    public function populateErrorInfo($e)
+    {
+        $this-> populateTotalExecutionTime();
+        $this-> statusCode = $e-> getCode();
+        $this-> headerCorrelationId = $e-> getResponse()-> getHeader('x-correlation-id')[0];
+        $this-> exceptionMessage = $e-> getResponse()->getBody()->getContents();
+    }
+
+    private function populateCommonResponseInfo($response)
+    {
+        $this-> populateTotalExecutionTime();
+        $this-> headerCorrelationId = $response-> getHeader('x-correlation-id')[0];
+        $this-> statusCode = $response-> getStatusCode();
+    }
+
+    private function populateTotalExecutionTime() 
+    {
+        $time_elapsed_secs = microtime(true) - $this-> startTime;
+        $milliseconds = round($time_elapsed_secs * 1000);
+        $this-> totalExecutionTime = $milliseconds; 
+    }    
+}
+?>

--- a/src/LogObject.php
+++ b/src/LogObject.php
@@ -4,7 +4,7 @@ namespace Avalara;
 class LogInformation
 {
     private $startTime;
-    private $includeReqResInLogging;
+    private $logRequestAndResponseBody;
     public $httpMethod;
     public $headerCorrelationId;
     public $requestDetails;
@@ -20,13 +20,13 @@ class LogInformation
         $this-> startTime = $startTime;
     }
 
-    public function populateRequestInfo($verb, $apiUrl, $guzzleParams, $includeReqResInLogging)
+    public function populateRequestInfo($verb, $apiUrl, $guzzleParams, $logRequestAndResponseBody)
     {
         $this-> timestamp = gmdate("Y/m/d H:i:s");
         $this-> httpMethod = $verb;
         $this-> requestURI = $apiUrl;
-        $this-> includeReqResInLogging = $includeReqResInLogging;
-        if($this-> includeReqResInLogging)
+        $this-> logRequestAndResponseBody = $logRequestAndResponseBody;
+        if($this-> logRequestAndResponseBody)
         {
             $this-> requestDetails = $guzzleParams['body'];
         }
@@ -35,7 +35,7 @@ class LogInformation
     public function populateResponseInfo($jsonBody, $response)
     {
         $this-> populateCommonResponseInfo($response);
-        if($this-> includeReqResInLogging)
+        if($this-> logRequestAndResponseBody)
         {
             $this-> responseDetails = $jsonBody;
         }


### PR DESCRIPTION
* SDK uses PSR-3, a common interface used for logging capabilities in PHP.
* Client would implement the binding on their end like Monolog, Analog etc to enable logging.
* By default there is no logging enabled.
* All the attributes which are part of log message are in **LogObject.php**
* To enable or disable logging of request and response object, there is a boolean variable **logRequestAndResponseBody** passed as constructor argument. Default is set to **FALSE**
* Output of logging is in **JSON** format.