### PR TITLE
Back door PHP 8.0 requirement through psr\log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": ">=5.5.9",
         "guzzlehttp/guzzle": "~6|~7",
-        "psr/log": "^3.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7"


### PR DESCRIPTION
Versions 22+ state they require PHP `>=5.5.9` but are requiring `"psr\log": "^3.0"` which has a hard requirement on PHP 8.

As a consumer of `psr\log` there should be no issue with supporting all three versions, as the only differences are type hinting.

This PR widens the `psr\log` requirement to allow versions 1, 2, or 3, which is a very common pattern across libraries.