### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "psr/log": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
+    "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": ">=5.7"
   },
   "support": {
@@ -58,6 +59,7 @@
     ]
   },
   "scripts": {
-    "test": "php -d xdebug.profiler_enable=on vendor/bin/phpunit --configuration tests/phpunit.xml"
+    "test": "php -d xdebug.profiler_enable=on vendor/bin/phpunit --configuration tests/phpunit.xml",
+    "phpstan": "vendor/bin/phpstan analyse -c phpstan.neon --memory-limit 1G"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 1
+    paths:
+        - src
+        - tests
+    phpVersion: 80403 # PHP 8.4.3
+    treatPhpDocTypesAsCertain: false

--- a/src/Client.php
+++ b/src/Client.php
@@ -65,7 +65,7 @@ class AvaTaxClientBase
      *
      * @throws \Exception
      */
-    public function __construct($appName, $appVersion, $machineName="", $environment="", $guzzleParams = [], LoggerInterface $logger = null, $logRequestAndResponseBody = false)
+    public function __construct($appName, $appVersion, $machineName="", $environment="", $guzzleParams = [], ?LoggerInterface $logger = null, $logRequestAndResponseBody = false)
     {
         // app name and app version are mandatory fields.
         if ($appName == "" || $appName == null || $appVersion == "" || $appVersion == null) {

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -2706,7 +2706,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @return \stdClass
      */
     public function bulkUploadCostCenters($companyid, $model=null)    {
-        $path = "/api/v2/companies/{$companyid}/costcenters/$upload";
+        $path = "/api/v2/companies/{$companyid}/costcenters/upload";
         $guzzleParams = [
             'query' => [],
             'body' => json_encode($model)
@@ -6072,7 +6072,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @return \stdClass
      */
     public function bulkUploadGLAccounts($companyid, $model=null)    {
-        $path = "/api/v2/companies/{$companyid}/glaccounts/$upload";
+        $path = "/api/v2/companies/{$companyid}/glaccounts/upload";
         $guzzleParams = [
             'query' => [],
             'body' => json_encode($model)
@@ -6611,7 +6611,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @return \stdClass
      */
     public function dismissHSCodeClassificationStatus($companyId, $itemId, $country)    {
-        $path = "/api/v2/companies/{$companyId}/items/{$itemId}/hscode-classifications-status/$dismiss";
+        $path = "/api/v2/companies/{$companyId}/items/{$itemId}/hscode-classifications-status/dismiss";
         $guzzleParams = [
             'query' => ['country' => $country],
             'body' => null
@@ -6805,7 +6805,7 @@ class AvaTaxClient extends AvaTaxClientBase
      * @return \stdClass
      */
     public function initiateHSCodeClassification($companyId, $model=null)    {
-        $path = "/api/v2/companies/{$companyId}/items/$initiate-hscode-classification";
+        $path = "/api/v2/companies/{$companyId}/items/initiate-hscode-classification";
         $guzzleParams = [
             'query' => [],
             'body' => json_encode($model)

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -640,7 +640,7 @@ class TransactionBuilder
     {
         $c = count($this->_model['lines']);
         if ($c <= 0) {
-            throw new \Exception("No lines have been added. The $memberName method applies to the most recent line.  To use this function, first add a line.");
+            throw new \Exception("No lines have been added. The memberName method applies to the most recent line.  To use this function, first add a line.");
         }
 
         return $c-1;

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -423,7 +423,7 @@ class TransactionBuilder
     {
         // Address the DateOverride constraint.
         if (($type == TaxOverrideType::C_TAXDATE) && (empty($taxDate))) {
-            throw new Exception("A valid date is required for a Tax Date Tax Override.");
+            throw new \Exception("A valid date is required for a Tax Date Tax Override.");
         }
 
         $li = $this->getMostRecentLineIndex();


### PR DESCRIPTION
Fixes some obvious typos (undefined class and variable names) and one nullable type hint which throws an error in PHP 8.4.